### PR TITLE
Correct UMD definition

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,14 +1,14 @@
 ( function( factory ) {
 
     if ( typeof define === "function" && define.amd ) {
-        define( "jquery-deferred-reporter", [], factory );
-    } else if ( typeof exports === "object" ) {
-        module.exports = factory();
+        define( "jquery-deferred-reporter", [ "jquery" ], factory );
+    } else if ( typeof module === "object" && module.exports ) {
+        module.exports = factory( require( "jquery" ) );
     } else {
-        factory();
+        factory( jQuery );
     }
 
-}( function() {
+}( function( jQuery ) {
 
 	function getStackHook() {
 


### PR DESCRIPTION
Since this plugin depends on jQuery, it should properly declare that dependency and load it from the associated loader if available.  Also corrected the condition in the CommonJS variant.

There are no existing unit tests for any of the UMD stuff, so none were provided here.
